### PR TITLE
Support for FLOPs in nn.Modules with input other than tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ### Added
 - `warm_up_fn` overload option.
+- Support for FLOPs count in torch.nn.Module with input other than Tensor.
 
 
 ## [0.3.0] - 2022-02-15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 
 ## [Unreleased]
+### Removed
+- `try_custom_warmup`.
+
+### Added
+- `warm_up_fn` overload option.
 
 
 ## [0.3.0] - 2022-02-15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 
 ## [Unreleased]
+
+
+## [0.3.1] - 2022-02-17]
 ### Removed
 - `try_custom_warmup`.
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ results = benchmark(model, sample, num_runs=100)
 ## How we benchmark
 The overall flow can be summarized with the diagram shown below (best viewed on GitHub):
 ```mermaid
-flowchart LR;
+flowchart TB;
     A([Start]) --> B
     B(prepare_samples)
     B --> C[get_machine_info]

--- a/README.md
+++ b/README.md
@@ -249,9 +249,45 @@ results = benchmark(model, sample, num_runs=100)
 
 ... Your turn
 
+## How we benchmark
+The overall flow can be summarized with the diagram shown below (best viewed on GitHub):
+```mermaid
+flowchart LR;
+    A([Start]) --> B
+    B(prepare_samples)
+    B --> C[get_machine_info]
+    C --> D[measure_params]
+    D --> E[warm_up, batch_size=1]
+    E --> F[measure_flops]
+    
+    subgraph SG[Repeat for batch_size 1 and x]
+        direction TB
+        G[measure_allocated_memory]
+        G --> H[warm_up, given batch_size]
+        H --> I[measure_detailed_inference_timing]
+        I --> J[measure_repeated_inference_timing]
+        J --> K[measure_energy]
+    end
+
+    F --> SG
+    SG --> END([End])
+```
+
+In cases where the sample and model don't reside on the same device (e.g. if a GPU is used for inference), we measure timing in three parts: `cpu_to_gpu`, `on_device_inference`, and `gpu_to_cpu`, as well as a sum of the three, `total`. The inference flow is shown below:
+
+```mermaid
+flowchart LR;
+    A([sample])
+    A --> B[cpu -> gpu]
+    B --> C[model __call__]
+    C --> D[gpu -> cpu]
+    D --> E([result])
+```
+
 ## Advanced use
 Trying to benchmark a custom class, which is not a `torch.nn.Module`?
-- You can pass custom functions to `benchmark` as seen in [this example](tests/test_custom_class.py).
+You can pass custom functions to `benchmark` as seen in [this example](tests/test_custom_class.py).
+
 
 ## Limitations
 - Allocated memory measurements are only available on CUDA devices.

--- a/pytorch_benchmark/benchmark.py
+++ b/pytorch_benchmark/benchmark.py
@@ -19,23 +19,6 @@ def _is_valid(val):
     return val == val
 
 
-def try_custom_warmup(model, shape):
-    # Allow custom warm-up function defined in model, e.g.
-    # class Model:
-    #
-    #   def warm_up(self, input_shape: List[int]):
-    #       ...
-    success = False
-    try:
-        if hasattr(model, "warm_up"):
-            model.warm_up(shape)
-            success = True
-    except Exception:
-        pass
-
-    return success
-
-
 def measure_flops(model, sample, print_details=False):
     flops = _INVALID
     try:
@@ -286,6 +269,7 @@ def benchmark(
     sample_with_batch_size1: Any = None,
     batch_size: int = None,
     print_fn=logger.info,
+    warm_up_fn=warm_up,
 ):
     results = {}
     batch_size = batch_size or sample.shape[0]
@@ -322,7 +306,14 @@ def benchmark(
         print_fn(f"Model parameters: {params} ({format_num(params)})")
 
     # Measure FLOPs
-    try_custom_warmup(model, sample1)
+    warm_up_fn(
+        model,
+        sample1,
+        model_device,
+        transfer_to_device_fn,
+        num_runs=1,
+        batch_size=1,
+    )
 
     flops = measure_flops(model, sample1, print_details)
     if _is_valid(flops):
@@ -365,7 +356,7 @@ def benchmark(
                 )
 
             # Inference timing
-            warm_up(
+            warm_up_fn(
                 model,
                 s,
                 model_device,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="pytorch-benchmark",
-    version="0.3.0",
+    version="0.3.1",
     description="Easily benchmark PyTorch model FLOPs, latency, throughput, max allocated memory and energy consumption in one go.",
     long_description=long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Removed
- `try_custom_warmup`.

### Added
- `warm_up_fn` overload option.
- Support for FLOPs count in torch.nn.Module with input other than Tensor.
